### PR TITLE
SwiftUIレイアウト一本勝負001

### DIFF
--- a/SwiftUI-OneShot.xcodeproj/project.pbxproj
+++ b/SwiftUI-OneShot.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		88C755BA287F9821004F1D13 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C755B9287F9821004F1D13 /* ContentView.swift */; };
 		88C755BC287F9822004F1D13 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88C755BB287F9822004F1D13 /* Assets.xcassets */; };
 		88C755BF287F9822004F1D13 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88C755BE287F9822004F1D13 /* Preview Assets.xcassets */; };
+		88C755CB287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +20,7 @@
 		88C755B9287F9821004F1D13 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		88C755BB287F9822004F1D13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		88C755BE287F9822004F1D13 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUIレイアウト1本勝負🪬001.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,8 +53,8 @@
 		88C755B6287F9821004F1D13 /* SwiftUI-OneShot */ = {
 			isa = PBXGroup;
 			children = (
-				88C755B7287F9821004F1D13 /* SwiftUI_OneShotApp.swift */,
-				88C755B9287F9821004F1D13 /* ContentView.swift */,
+				88C755C7287F9D83004F1D13 /* Application */,
+				88C755C9287F9DBE004F1D13 /* Screen */,
 				88C755BB287F9822004F1D13 /* Assets.xcassets */,
 				88C755BD287F9822004F1D13 /* Preview Content */,
 			);
@@ -65,6 +67,31 @@
 				88C755BE287F9822004F1D13 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		88C755C7287F9D83004F1D13 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				88C755B7287F9821004F1D13 /* SwiftUI_OneShotApp.swift */,
+			);
+			path = Application;
+			sourceTree = "<group>";
+		};
+		88C755C8287F9DB2004F1D13 /* #001 */ = {
+			isa = PBXGroup;
+			children = (
+				88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift */,
+			);
+			path = "#001";
+			sourceTree = "<group>";
+		};
+		88C755C9287F9DBE004F1D13 /* Screen */ = {
+			isa = PBXGroup;
+			children = (
+				88C755B9287F9821004F1D13 /* ContentView.swift */,
+				88C755C8287F9DB2004F1D13 /* #001 */,
+			);
+			path = Screen;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,6 +164,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88C755CB287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift in Sources */,
 				88C755BA287F9821004F1D13 /* ContentView.swift in Sources */,
 				88C755B8287F9821004F1D13 /* SwiftUI_OneShotApp.swift in Sources */,
 			);
@@ -267,7 +295,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftUI-OneShot/Preview Content\"";
-				DEVELOPMENT_TEAM = H2XW5KQ42M;
+				DEVELOPMENT_TEAM = XDN4GBQ9L4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -296,7 +324,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftUI-OneShot/Preview Content\"";
-				DEVELOPMENT_TEAM = H2XW5KQ42M;
+				DEVELOPMENT_TEAM = XDN4GBQ9L4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/SwiftUI-OneShot.xcodeproj/project.pbxproj
+++ b/SwiftUI-OneShot.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		88C755BA287F9821004F1D13 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C755B9287F9821004F1D13 /* ContentView.swift */; };
 		88C755BC287F9822004F1D13 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88C755BB287F9822004F1D13 /* Assets.xcassets */; };
 		88C755BF287F9822004F1D13 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88C755BE287F9822004F1D13 /* Preview Assets.xcassets */; };
-		88C755CB287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift */; };
+		88C755CB287F9FB7004F1D13 /* SwiftUIレイアウト一本勝負🪬001.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト一本勝負🪬001.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,7 +20,7 @@
 		88C755B9287F9821004F1D13 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		88C755BB287F9822004F1D13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		88C755BE287F9822004F1D13 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUIレイアウト1本勝負🪬001.swift"; sourceTree = "<group>"; };
+		88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト一本勝負🪬001.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUIレイアウト一本勝負🪬001.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,7 +80,7 @@
 		88C755C8287F9DB2004F1D13 /* #001 */ = {
 			isa = PBXGroup;
 			children = (
-				88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift */,
+				88C755CA287F9FB7004F1D13 /* SwiftUIレイアウト一本勝負🪬001.swift */,
 			);
 			path = "#001";
 			sourceTree = "<group>";
@@ -164,7 +164,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				88C755CB287F9FB7004F1D13 /* SwiftUIレイアウト1本勝負🪬001.swift in Sources */,
+				88C755CB287F9FB7004F1D13 /* SwiftUIレイアウト一本勝負🪬001.swift in Sources */,
 				88C755BA287F9821004F1D13 /* ContentView.swift in Sources */,
 				88C755B8287F9821004F1D13 /* SwiftUI_OneShotApp.swift in Sources */,
 			);

--- a/SwiftUI-OneShot/Application/SwiftUI_OneShotApp.swift
+++ b/SwiftUI-OneShot/Application/SwiftUI_OneShotApp.swift
@@ -2,7 +2,7 @@
 //  SwiftUI_OneShotApp.swift
 //  SwiftUI-OneShot
 //
-//  Created by Naoki Muramoto on 2022/07/14.
+//  Created by Naoki on 2022/07/14.
 //
 
 import SwiftUI

--- a/SwiftUI-OneShot/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SwiftUI-OneShot/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -72,6 +72,11 @@
     },
     {
       "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
       "scale" : "2x",
       "size" : "76x76"
     },

--- a/SwiftUI-OneShot/Screen/#001/SwiftUIレイアウト1本勝負🪬001.swift
+++ b/SwiftUI-OneShot/Screen/#001/SwiftUIレイアウト1本勝負🪬001.swift
@@ -1,0 +1,42 @@
+//
+//  OneShotView001.swift
+//  SwiftUI-OneShot
+//
+//  Created by Naoki on 2022/07/14.
+//
+
+import SwiftUI
+
+struct SwiftUIレイアウト1本勝負🪬001: View {
+    // MARK: - Prperties
+    private let text = "Hello, World! Helloooo!"
+
+    // MARK: - body
+    var body: some View {
+        VStack {
+            HStack {
+                Text(text).layoutPriority(1)
+                Spacer()
+                Text(text)
+            } //: HStack
+            Spacer()
+            Text(text)
+            Spacer()
+            HStack {
+                Text(text)
+                Spacer()
+                Text(text).layoutPriority(1)
+            } //: HStack
+        } //: VStack
+        .padding()
+    }
+}
+
+struct SwiftUIレイアウト1本勝負🪬001_preview: PreviewProvider {
+    static var previews: some View {
+        SwiftUIレイアウト1本勝負🪬001()
+            .previewDisplayName("iPhone 13 Pro Max")
+            .previewDevice(PreviewDevice(rawValue: "iPhone 13 Pro Max"))
+        SwiftUIレイアウト1本勝負🪬001()
+    }
+}

--- a/SwiftUI-OneShot/Screen/#001/SwiftUIレイアウト一本勝負🪬001.swift
+++ b/SwiftUI-OneShot/Screen/#001/SwiftUIレイアウト一本勝負🪬001.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SwiftUIレイアウト1本勝負🪬001: View {
+struct SwiftUIレイアウト一本勝負🪬001: View {
     // MARK: - Prperties
     private let text = "Hello, World! Helloooo!"
 
@@ -34,9 +34,9 @@ struct SwiftUIレイアウト1本勝負🪬001: View {
 
 struct SwiftUIレイアウト1本勝負🪬001_preview: PreviewProvider {
     static var previews: some View {
-        SwiftUIレイアウト1本勝負🪬001()
+        SwiftUIレイアウト一本勝負🪬001()
             .previewDisplayName("iPhone 13 Pro Max")
             .previewDevice(PreviewDevice(rawValue: "iPhone 13 Pro Max"))
-        SwiftUIレイアウト1本勝負🪬001()
+        SwiftUIレイアウト一本勝負🪬001()
     }
 }

--- a/SwiftUI-OneShot/Screen/#001/SwiftUIレイアウト一本勝負🪬001.swift
+++ b/SwiftUI-OneShot/Screen/#001/SwiftUIレイアウト一本勝負🪬001.swift
@@ -1,5 +1,5 @@
 //
-//  OneShotView001.swift
+//  SwiftUIレイアウト一本勝負🪬001.swift
 //  SwiftUI-OneShot
 //
 //  Created by Naoki on 2022/07/14.

--- a/SwiftUI-OneShot/Screen/ContentView.swift
+++ b/SwiftUI-OneShot/Screen/ContentView.swift
@@ -2,7 +2,7 @@
 //  ContentView.swift
 //  SwiftUI-OneShot
 //
-//  Created by Naoki Muramoto on 2022/07/14.
+//  Created by Naoki on 2022/07/14.
 //
 
 import SwiftUI


### PR DESCRIPTION
## お題
> [#SwiftUIレイアウト一本勝負](https://twitter.com/hashtag/SwiftUI%E3%83%AC%E3%82%A4%E3%82%A2%E3%82%A6%E3%83%88%E4%B8%80%E6%9C%AC%E5%8B%9D%E8%B2%A0?src=hashtag_click) 001
> - サイコロの「5」の目のように「Hello, world!」を配置してください
> - 画面サイズが小さいデバイスの場合は、上前端（top & leading）と下後端（bottom& trailing）の位置に来るテキストを優先して（=可能な限り改行させないで）表示してください

https://twitter.com/treastrain/status/1547154171379724289?s=20&t=tCtI3YjHrpxlLYSE_FMrdw

## スクリーンショット
<img width="1242" alt="スクリーンショット 2022-07-15 9 21 07" src="https://user-images.githubusercontent.com/70731623/179122258-9d909a0f-a247-4d39-a7de-6fe986589fd5.png">

